### PR TITLE
refactor: change page titles

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -19,15 +19,21 @@ export const routes: Routes = [
       user: userResolver,
     },
     children: [
+      // {
+      //   path: '',
+      //   loadChildren: () =>
+      //     import('./features/dashboard/dashboard.module').then(
+      //       m => m.DashboardModule
+      //     ),
+      // },
       {
         path: '',
-        loadChildren: () =>
-          import('./features/dashboard/dashboard.module').then(
-            m => m.DashboardModule
-          ),
+        redirectTo: 'workouts',
+        pathMatch: 'full',
       },
       {
         path: 'profile',
+        title: 'Perfil - Unifit',
         loadChildren: () =>
           import('./features/profile/profile.module').then(
             m => m.ProfileModule
@@ -35,6 +41,7 @@ export const routes: Routes = [
       },
       {
         path: 'workouts',
+        title: 'Treinos - Unifit',
         loadChildren: () =>
           import('./features/workouts/workouts.module').then(
             m => m.WorkoutsModule
@@ -42,6 +49,7 @@ export const routes: Routes = [
       },
       {
         path: 'admin',
+        title: 'Admin - Unifit',
         loadChildren: () =>
           import('./features/admin/admin.module').then(m => m.AdminModule),
         canActivate: [adminGuard],

--- a/src/app/core/services/http-interceptor.service.ts
+++ b/src/app/core/services/http-interceptor.service.ts
@@ -20,7 +20,7 @@ export const httpInterceptor: HttpInterceptorFn = (request, next) => {
   return next(request).pipe(
     catchError((error: HttpErrorResponse) => {
       if (error.status === 401 || error.status === 403) {
-        router.navigate(['/login']);
+        router.navigate(['/auth/login']);
       }
 
       return throwError(

--- a/src/app/features/admin/admin-routing.module.ts
+++ b/src/app/features/admin/admin-routing.module.ts
@@ -5,6 +5,7 @@ import { UsersComponent } from './pages/users/users.component';
 const routes: Routes = [
   {
     path: 'users',
+    title: 'Usuários - Unifit',
     component: UsersComponent,
   },
 ];

--- a/src/app/features/admin/guards/admin.guard.ts
+++ b/src/app/features/admin/guards/admin.guard.ts
@@ -16,7 +16,7 @@ export const adminGuard: CanActivateFn = () => {
   }
 
   if (!isAdmin) {
-    router.navigate(['/app']);
+    router.navigate(['/app/workouts']);
     return false;
   }
 

--- a/src/app/features/auth/auth-routing.module.ts
+++ b/src/app/features/auth/auth-routing.module.ts
@@ -9,8 +9,12 @@ const routes: Routes = [
     path: '',
     component: AuthLayoutComponent,
     children: [
-      { path: 'login', component: LoginComponent },
-      { path: 'register', component: RegisterComponent },
+      { path: 'login', title: 'Login - Unifit', component: LoginComponent },
+      {
+        path: 'register',
+        title: 'Criar conta - Unifit',
+        component: RegisterComponent,
+      },
     ],
   },
 ];

--- a/src/app/features/auth/pages/login/login.component.ts
+++ b/src/app/features/auth/pages/login/login.component.ts
@@ -69,7 +69,7 @@ export class LoginComponent {
         if (!response) return;
 
         this.globalStateService.loadCurrentUser();
-        this.router.navigate(['/app']);
+        this.router.navigate(['/app/workouts']);
       });
   }
 }

--- a/src/app/shared/components/sidebar/sidebar.component.html
+++ b/src/app/shared/components/sidebar/sidebar.component.html
@@ -5,7 +5,7 @@
 
   <nav class="flex-1 w-full">
     <ul class="flex flex-col w-full gap-2">
-      <li>
+      <!-- <li>
         <a
           (click)="handleLinkClick()"
           routerLink="/app"
@@ -18,13 +18,14 @@
           ></i>
           Home
         </a>
-      </li>
+      </li> -->
 
       <li>
         <a
           (click)="handleLinkClick()"
-          routerLink="/app/workouts"
+          routerLink="/app"
           routerLinkActive="!bg-gray-100"
+          [routerLinkActiveOptions]="{ exact: true }"
           class="flex items-center gap-4 px-4 py-2 text-sm transition-colors duration-200 border rounded-md cursor-pointer hover:bg-gray-50"
         >
           <i class="flex items-center justify-center text-lg pi pi-list"></i>

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
   <head>
     <meta charset="utf-8" />
-    <title>UniFit</title>
+    <title>Unifit</title>
     <base href="/" />
 
     <link


### PR DESCRIPTION
## Description

> The pages didn't have the correct names, all pages are titled as `UniFit` instead of `Treinos - Unifit`, for example.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/df31617e-23cd-4774-a4e4-f700178026ad)

### After

![image](https://github.com/user-attachments/assets/79d46c68-89f4-4ecf-bd31-76677231f56e)
